### PR TITLE
Create authorization service

### DIFF
--- a/Queueomatic/Server/Program.cs
+++ b/Queueomatic/Server/Program.cs
@@ -23,6 +23,10 @@ builder.Services.AddScoped<IUserRepository, UserRepository>();
 builder.Services.AddScoped<IRoomRepository, RoomRepository>();
 builder.Services.AddScoped<IUnitOfWork, UnitOfWork>();
 
+builder.Services.AddAuthorization(options =>
+{
+    options.AddPolicy("SignedInUser", x => x.RequireRole("User").RequireClaim("UserId"));
+});
 
 var app = builder.Build();
 

--- a/Queueomatic/Server/Program.cs
+++ b/Queueomatic/Server/Program.cs
@@ -26,6 +26,7 @@ builder.Services.AddScoped<IUnitOfWork, UnitOfWork>();
 builder.Services.AddAuthorization(options =>
 {
     options.AddPolicy("SignedInUser", x => x.RequireRole("User").RequireClaim("UserId"));
+    options.AddPolicy("ValidParticipant", x => x.RequireRole("Participant").RequireClaim("ParticipantId"));
 });
 
 var app = builder.Build();


### PR DESCRIPTION
Adds a couple of policies that can be used on endpoint authorization. There needs to be checks in the handler if the participant id is the same as the request id and if so do some kind of work. Otherwise anyone could delete and move users.

All other authorization should be implemented in the handlers. 

See [Fast Endpoints Authorization](https://fast-endpoints.com/docs/security#endpoint-authorization) for more information.

Closes #27 