### PR TITLE
Create participant repository

### DIFF
--- a/Queueomatic/Queueomatic.DataAccess/DataContexts/ApplicationContext.cs
+++ b/Queueomatic/Queueomatic.DataAccess/DataContexts/ApplicationContext.cs
@@ -7,6 +7,7 @@ public class ApplicationContext : DbContext
 {
     public DbSet<User> Users { get; set; }
     public DbSet<Room> Rooms { get; set; }
+    public DbSet<Participant> Participants { get; set; }
     public ApplicationContext(DbContextOptions<ApplicationContext> options) : base(options)
     {
 

--- a/Queueomatic/Queueomatic.DataAccess/Migrations/20230521214247_AddParticipantDbSet.Designer.cs
+++ b/Queueomatic/Queueomatic.DataAccess/Migrations/20230521214247_AddParticipantDbSet.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Queueomatic.DataAccess.DataContexts;
 
@@ -11,9 +12,11 @@ using Queueomatic.DataAccess.DataContexts;
 namespace Queueomatic.DataAccess.Migrations
 {
     [DbContext(typeof(ApplicationContext))]
-    partial class ApplicationContextModelSnapshot : ModelSnapshot
+    [Migration("20230521214247_AddParticipantDbSet")]
+    partial class AddParticipantDbSet
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Queueomatic/Queueomatic.DataAccess/Migrations/20230521214247_AddParticipantDbSet.cs
+++ b/Queueomatic/Queueomatic.DataAccess/Migrations/20230521214247_AddParticipantDbSet.cs
@@ -1,0 +1,78 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Queueomatic.DataAccess.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddParticipantDbSet : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Participant_Rooms_RoomId",
+                table: "Participant");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_Participant",
+                table: "Participant");
+
+            migrationBuilder.RenameTable(
+                name: "Participant",
+                newName: "Participants");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_Participant_RoomId",
+                table: "Participants",
+                newName: "IX_Participants_RoomId");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_Participants",
+                table: "Participants",
+                column: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Participants_Rooms_RoomId",
+                table: "Participants",
+                column: "RoomId",
+                principalTable: "Rooms",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Participants_Rooms_RoomId",
+                table: "Participants");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_Participants",
+                table: "Participants");
+
+            migrationBuilder.RenameTable(
+                name: "Participants",
+                newName: "Participant");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_Participants_RoomId",
+                table: "Participant",
+                newName: "IX_Participant_RoomId");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_Participant",
+                table: "Participant",
+                column: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Participant_Rooms_RoomId",
+                table: "Participant",
+                column: "RoomId",
+                principalTable: "Rooms",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/Queueomatic/Queueomatic.DataAccess/Repositories/Interfaces/IParticipantRepository.cs
+++ b/Queueomatic/Queueomatic.DataAccess/Repositories/Interfaces/IParticipantRepository.cs
@@ -2,7 +2,7 @@
 
 namespace Queueomatic.DataAccess.Repositories.Interfaces;
 
-public interface IParticipantRepository : IRepository<Participant, string>
+public interface IParticipantRepository : IRepository<Participant, Guid>
 {
     
 }

--- a/Queueomatic/Queueomatic.DataAccess/Repositories/Interfaces/IParticipantRepository.cs
+++ b/Queueomatic/Queueomatic.DataAccess/Repositories/Interfaces/IParticipantRepository.cs
@@ -1,0 +1,8 @@
+﻿using Queueomatic.DataAccess.Models;
+
+namespace Queueomatic.DataAccess.Repositories.Interfaces;
+
+public interface IParticipantRepository : IRepository<Participant, string>
+{
+    
+}

--- a/Queueomatic/Queueomatic.DataAccess/Repositories/ParticipantRepository.cs
+++ b/Queueomatic/Queueomatic.DataAccess/Repositories/ParticipantRepository.cs
@@ -14,11 +14,11 @@ public class ParticipantRepository : IParticipantRepository
         _context = context;
     }
 
-    public async Task<Participant?> GetAsync(string id)
+    public async Task<Participant?> GetAsync(Guid id)
     {
         return await _context.Participants
             .Include(x => x.Room)
-            .FirstOrDefaultAsync(p => p.Id == Guid.Parse(id));
+            .FirstOrDefaultAsync(p => p.Id == id);
     }
 
     public async Task<IEnumerable<Participant>> GetAllAsync()
@@ -39,7 +39,7 @@ public class ParticipantRepository : IParticipantRepository
         return Task.CompletedTask;
     }
 
-    public async Task DeleteAsync(string id)
+    public async Task DeleteAsync(Guid id)
     {
         var participant = await GetAsync(id);
         if (participant != null)

--- a/Queueomatic/Queueomatic.DataAccess/Repositories/ParticipantRepository.cs
+++ b/Queueomatic/Queueomatic.DataAccess/Repositories/ParticipantRepository.cs
@@ -1,0 +1,50 @@
+﻿using Microsoft.EntityFrameworkCore;
+using Queueomatic.DataAccess.DataContexts;
+using Queueomatic.DataAccess.Models;
+using Queueomatic.DataAccess.Repositories.Interfaces;
+
+namespace Queueomatic.DataAccess.Repositories;
+
+public class ParticipantRepository : IParticipantRepository
+{
+    private readonly ApplicationContext _context;
+
+    public ParticipantRepository(ApplicationContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<Participant?> GetAsync(string id)
+    {
+        return await _context.Participants
+            .Include(x => x.Room)
+            .FirstOrDefaultAsync(p => p.Id == Guid.Parse(id));
+    }
+
+    public async Task<IEnumerable<Participant>> GetAllAsync()
+    {
+        return await _context.Participants
+            .Include(x => x.Room)
+            .ToListAsync();
+    }
+
+    public async Task AddAsync(Participant entity)
+    {
+        await _context.Participants.AddAsync(entity);
+    }
+
+    public Task UpdateAsync(Participant entity)
+    {
+        _context.Update(entity);
+        return Task.CompletedTask;
+    }
+
+    public async Task DeleteAsync(string id)
+    {
+        var participant = await GetAsync(id);
+        if (participant != null)
+        {
+            _context.Participants.Remove(participant);
+        }
+    }
+}

--- a/Queueomatic/Queueomatic.DataAccess/UnitOfWork/IUnitOfWork.cs
+++ b/Queueomatic/Queueomatic.DataAccess/UnitOfWork/IUnitOfWork.cs
@@ -6,6 +6,7 @@ public interface IUnitOfWork
 {
     public IUserRepository UserRepository { get; }
     public IRoomRepository RoomRepository { get; }
+    public IParticipantRepository ParticipantRepository { get; }
     public Task<int> SaveAsync();
     public void Dispose();
 

--- a/Queueomatic/Queueomatic.DataAccess/UnitOfWork/UnitOfWork.cs
+++ b/Queueomatic/Queueomatic.DataAccess/UnitOfWork/UnitOfWork.cs
@@ -15,9 +15,17 @@ public class UnitOfWork : IDisposable, IUnitOfWork
         UserRepository = userRepository;
         RoomRepository = roomRepository;
     }
+    
+    public UnitOfWork(ApplicationContext context, IParticipantRepository participantRepository, IRoomRepository roomRepository)
+    {
+        _context = context;
+        ParticipantRepository = participantRepository;
+        RoomRepository = roomRepository;
+    }
 
     public IUserRepository UserRepository { get; }
     public IRoomRepository RoomRepository { get; }
+    public IParticipantRepository ParticipantRepository { get; }
 
     public async Task<int> SaveAsync()
     {

--- a/Queueomatic/Queueomatic.Test/ParticipantRepository_ReturnCorrectValue.cs
+++ b/Queueomatic/Queueomatic.Test/ParticipantRepository_ReturnCorrectValue.cs
@@ -1,0 +1,55 @@
+﻿using FakeItEasy;
+using Microsoft.EntityFrameworkCore;
+using Queueomatic.DataAccess.DataContexts;
+using Queueomatic.DataAccess.Models;
+using Queueomatic.DataAccess.Repositories.Interfaces;
+using Queueomatic.DataAccess.UnitOfWork;
+
+namespace Queueomatic.Test;
+
+public class ParticipantRepository_ReturnCorrectValue
+{
+    [Fact]
+    public async Task GetParticipant_ReturnParticipantOrNull()
+    {
+        //Arrange
+        var options = new DbContextOptionsBuilder<ApplicationContext>()
+            .UseInMemoryDatabase(databaseName: "QueueomaticTestDatabase")
+            .Options;
+
+        var participant = A.Fake<Participant>();
+        var participantRepository = A.Fake<IParticipantRepository>();
+        var roomRepository = A.Fake<IRoomRepository>();
+        A.CallTo(() => participantRepository.GetAsync(participant.Id)).Returns(participant);
+
+        //Act   
+        await using var context = new ApplicationContext(options);
+        var sut = new UnitOfWork(context, participantRepository, roomRepository);
+        var result = await sut.ParticipantRepository.GetAsync(participant.Id);
+
+        //Assert
+        Assert.Equivalent(participant, result);
+    }
+
+    [Fact]
+    public async Task GetAllParticipants_ReturnTotalParticipant()
+    {
+        //Arrange
+        var options = new DbContextOptionsBuilder<ApplicationContext>()
+            .UseInMemoryDatabase(databaseName: "QueueomaticTestDatabase")
+            .Options;
+
+        var participants = A.Fake<IEnumerable<Participant>>();
+        var participantRepository = A.Fake<IParticipantRepository>();
+        var roomRepository = A.Fake<IRoomRepository>();
+        A.CallTo(() => participantRepository.GetAllAsync()).Returns(participants);
+
+        //Act   
+        await using var context = new ApplicationContext(options);
+        var sut = new UnitOfWork(context, participantRepository, roomRepository);
+        var result = await sut.RoomRepository.GetAllAsync();
+
+        //Assert
+        Assert.True(participants.Count() == result.Count());
+    }
+}

--- a/Queueomatic/Server/Program.cs
+++ b/Queueomatic/Server/Program.cs
@@ -26,6 +26,7 @@ builder.Services.AddRazorPages();
 
 builder.Services.AddScoped<IUserRepository, UserRepository>();
 builder.Services.AddScoped<IRoomRepository, RoomRepository>();
+builder.Services.AddScoped<IParticipantRepository, ParticipantRepository>();
 builder.Services.AddScoped<IUnitOfWork, UnitOfWork>();
 builder.Services.AddScoped<IAuthenticationService, AuthenticationService>();
 builder.Services.AddScoped<IRoomService, RoomService>();


### PR DESCRIPTION
It seems to be needed since we store the participants in the database, even though it is temporary.

The reason that I overload the UOW constructor is that we don't need to initialize the user repository when we work with participants and rooms.


Closes #87 