### PR TITLE
Migrate signal r interfaces

### DIFF
--- a/Queueomatic/Client/Pages/Room.razor.cs
+++ b/Queueomatic/Client/Pages/Room.razor.cs
@@ -87,7 +87,7 @@ public partial class Room : ComponentBase
             StateHasChanged();
         });
 
-        hubConnection.On<ParticipantRoomDto>("ClearTheRoom", (user) =>
+        hubConnection.On<ParticipantRoomDto>("ClearRoom", (user) =>
         {
             ClearTheRoom(user);
             StateHasChanged();
@@ -97,7 +97,7 @@ public partial class Room : ComponentBase
             UpdateRoom(room);
             StateHasChanged();
         });
-        hubConnection.On("KickFromRoom", async () =>
+        hubConnection.On("KickParticipant", async () =>
         {
             await SessionStorageService.RemoveItemAsync("authToken");
             Navigation.NavigateTo("/");

--- a/Queueomatic/Client/Pages/Room.razor.cs
+++ b/Queueomatic/Client/Pages/Room.razor.cs
@@ -92,11 +92,6 @@ public partial class Room : ComponentBase
             ClearTheRoom(user);
             StateHasChanged();
         });
-        hubConnection.On<RoomModel>("UpdateRoom", (room) =>
-        {
-            UpdateRoom(room);
-            StateHasChanged();
-        });
         hubConnection.On("KickParticipant", async () =>
         {
             await SessionStorageService.RemoveItemAsync("authToken");

--- a/Queueomatic/Server/Endpoints/Hubs/Room/IRoomClient.cs
+++ b/Queueomatic/Server/Endpoints/Hubs/Room/IRoomClient.cs
@@ -1,11 +1,10 @@
-﻿using Queueomatic.DataAccess.Models;
-using Queueomatic.Shared.DTOs;
+﻿using Queueomatic.Shared.DTOs;
 
 namespace Queueomatic.Server.Endpoints.Hubs.Room;
 
 public interface IRoomClient
 {
-    public Task MoveParticipant(ParticipantRoomDto participantToBeUpdated, Status status);
+    public Task MoveParticipant(ParticipantRoomDto participantToBeUpdated, StatusDto status);
     public Task ClearRoom(ParticipantRoomDto participant);
     public Task KickParticipant();
 }

--- a/Queueomatic/Server/Endpoints/Hubs/Room/IRoomClient.cs
+++ b/Queueomatic/Server/Endpoints/Hubs/Room/IRoomClient.cs
@@ -1,0 +1,11 @@
+﻿using Queueomatic.DataAccess.Models;
+using Queueomatic.Shared.DTOs;
+
+namespace Queueomatic.Server.Endpoints.Hubs.Room;
+
+public interface IRoomClient
+{
+    public Task MoveParticipant(ParticipantRoomDto participantToBeUpdated, Status status);
+    public Task ClearRoom(ParticipantRoomDto participant);
+    public Task KickParticipant();
+}

--- a/Queueomatic/Server/Endpoints/Hubs/Room/RoomHub.cs
+++ b/Queueomatic/Server/Endpoints/Hubs/Room/RoomHub.cs
@@ -45,7 +45,7 @@ public class RoomHub : Hub
         if (string.IsNullOrWhiteSpace(connectionId))
             connectionId = null;
 
-        await Clients.Groups(roomId).SendAsync("ClearTheRoom", participant);
+        await Clients.Groups(roomId).SendAsync("ClearRoom", participant);
         await Groups.RemoveFromGroupAsync(connectionId ?? Context.ConnectionId, roomId);
         _cacheService.CleanRoom(participant, roomId);
     }
@@ -60,6 +60,6 @@ public class RoomHub : Hub
     {
         var participant = _cacheService.GetParticipant(participantId, roomId);
         await LeaveRoom(participant, roomId, connectionIdOfParticipant);
-        await Clients.Client(connectionIdOfParticipant).SendAsync("KickFromRoom");
+        await Clients.Client(connectionIdOfParticipant).SendAsync("KickParticipant");
     }
 }

--- a/Queueomatic/Server/Endpoints/Hubs/Room/RoomHub.cs
+++ b/Queueomatic/Server/Endpoints/Hubs/Room/RoomHub.cs
@@ -1,7 +1,5 @@
 ﻿using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
-using Microsoft.Extensions.Caching.Memory;
-using Queueomatic.DataAccess.Models;
 using Queueomatic.Server.Services.CacheRoomService;
 using Queueomatic.Shared.DTOs;
 using Queueomatic.Shared.Models;


### PR DESCRIPTION
RoomHub methods are based on an interface instead of strings.

Close #142 